### PR TITLE
support for 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: python
 
 python:
-  - 3.6
+  - 3.5
 
 env:
   global:
     - PGUSER=postgres
     # GH_TOKEN to push API docs
     - secure: "jYePkfPWC/zfdFR0GIgsPtWaJy6sio4QILcl7eWySPmiC6NPKpV33FaCn/hpBw4F9BhjRO4Hn6gGW0Tu10MY3RmNnnCJSLiTTeMv2teXWh2Xc3bLEeXVGJMiJBhlQyM1PRf0cVpLqG+r4sv++ehl2izBimkX0RB5OCEQHslVtuIOilshyniVZ9AInBKRNzvT02+CIeIuI2WLpgf+xBjyTWbQSJBDGMxrPcJMiE3UzufMSpmE7ooWTTw5b6B8SumvkbER7Iqu1Ms1VrV7lnyeKe+9mwmc8SYtGdCTu8k3/5l3d3++CTE09Od4fXTIGmxrrCUUp7cueLkQm2nEpdGj93Q+hgU21kSAhpNupsdseeKz2SKT6skwnCi0C7HPu0qX7B5qteqtEbgsBnGV9K+lHAuH6psksLDO9g1w6ipCZJwL8L1vOCMHVSt3urvYBc52Ms2lh7rO0iPj0TvF/qUncORlneL5HJcInAAHecV9A2UCuahMtqgFBUeD+3FxmmF+h+p2t0fo1m4s+/yUMtECMjfqQdM6CgxVHCqg/JoRccQHkexwSwnkT7RvJ8HhtLsd/GyTCdcVCTQNgb+JtL02GAvOmI5+1sl+gew0WTSoIMexivSJ3Y1yFuLI2fOTJh5K20BzEaBY97JdFcgvh3DzxlvUaL7DgAHWUbeGMyY+fO8="
+  jobs:
+    - POSTGRESQL_VERSION=9.6
+    - POSTGRESQL_VERSION=10
+    - POSTGRESQL_VERSION=11
 
 jobs:
   include:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import sys
 
-python_min_version = (3, 6)
+python_min_version = (3, 5)
 
 if sys.version_info < python_min_version:
     sys.exit('Pirogue requires at least Python version {vmaj}.{vmin}.\n'


### PR DESCRIPTION
It seems the library works under 3.5 (at least tests pass and no issue with qgep/pum with initial testings), but install is prevented in setup.py.

Can we support 3.5 ?