### PR TITLE
Keep primary column first in views

### DIFF
--- a/pirogue/utils.py
+++ b/pirogue/utils.py
@@ -414,6 +414,8 @@ def __column_priority(column: str, columns_on_top: list=[], columns_at_end: list
     """
     Returns a value to sort columns first by priority (on top / at end), then alphabetically
     """
+    if column == 'obj_id':
+        return [-1, column]
     if column in columns_on_top:
         return [0, column]
     elif column in columns_at_end:


### PR DESCRIPTION
https://github.com/opengisch/pirogue/pull/14 altered column order alphabetically. Yet QGIS seems to implicitly use the first one as a primary key.

This adds some logic to determine the PK column and put it at the front in the views.

(initial issue : https://github.com/QGEP/QGEP/issues/662)